### PR TITLE
ゴールオブジェクトに衝突時の処理を追加

### DIFF
--- a/src/application/component/map/MapFactory.java
+++ b/src/application/component/map/MapFactory.java
@@ -109,6 +109,7 @@ public class MapFactory {
                         //== '0' のときはプレイヤーとして
                         if ( iChar == '0' ) {
                             // プレイヤー
+                            System.out.println(pos);
                             factoryList.add(0, PlayerFactory.getInstance(pos));
                         } else {
                             // エネミー

--- a/src/application/component/objects/stage/implement_stage/GoalBlock.java
+++ b/src/application/component/objects/stage/implement_stage/GoalBlock.java
@@ -4,7 +4,9 @@ import application.component.objects.ImageManager;
 import application.component.objects.RectangleCollisionObject;
 import application.component.objects.stage.StageObject;
 import application.component.system.GameEnvironment;
+import application.component.system.GameManager;
 import application.component.system.character.factory.PlayerFactory;
+import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.image.Image;
 
@@ -28,7 +30,7 @@ public class GoalBlock extends StageObject {
         rectCO.addEvent((ed, go, ing) -> {
             PlayerFactory.getPlayerCharacterController().ifPresent(player -> {
                 if ( go == player.getCharacter() ) {
-                    // TODO　GameManagerに対して、ゲームクリアリクエストを送る処理を追加する
+                    Platform.runLater(() -> GameManager.requestGoal());
                     System.out.println("ゴール");
                 }
             });

--- a/src/application/component/system/DrawPanelManager.java
+++ b/src/application/component/system/DrawPanelManager.java
@@ -37,7 +37,7 @@ public class DrawPanelManager {
      * @param gm the gm
      */
     private void inputMap(GameMap gm) {
-        drawPane.getChildren().removeAll();  // 既存要素の削除
+        drawPane.getChildren().clear();  // 既存要素の削除
         drawPane.setPrefWidth(gm.getMapWidth());
         drawPane.setPrefHeight(gm.getMapHeight());
         // TODO GameObject実装後、実装

--- a/src/application/component/system/GameManager.java
+++ b/src/application/component/system/GameManager.java
@@ -10,7 +10,7 @@ import application.component.objects.character.OffensiveObject;
 import application.component.system.character.controller.Player;
 import application.component.system.character.factory.CharacterFactory;
 import application.component.system.character.factory.PlayerFactory;
-import javafx.application.Platform;
+import application.controller.TitleController;
 import javafx.scene.layout.Pane;
 import lib.TupleUtil;
 
@@ -28,7 +28,6 @@ import static application.component.system.GameManager.GameProcessState.*;
 public class GameManager {
     private static final GameManager ourInstance = new GameManager();
     private static final int PROCESS_INTERVAL_MILLISECOND = 35;           // 処理の間隔
-    private static final InputManager inputManager = new InputManager();  // 入力キー管理
 
     private int stageNum;     // 現在選択肢ているステージ番号
     private Pane drawPane;    // 使用するパネル
@@ -38,7 +37,8 @@ public class GameManager {
     private Timer gameTimer;        // ゲームプロセス用タイマー
     private Player player;          // プレイヤーコントローラ
 
-    private DrawPanelManager dpm;   // パネル管理
+    private DrawPanelManager dpm;       // パネル管理
+    private InputManager inputManager;  // 入力キー管理
 
     /**
      * インスタンスの取得
@@ -50,15 +50,24 @@ public class GameManager {
     public static GameManager getInstance(Pane drawPane, int stageNum) {
         ourInstance.stageNum = stageNum;
         ourInstance.drawPane = drawPane;
+        ourInstance.inputManager = new InputManager();
         return ourInstance;
     }
 
     public static void setKeyState(InputManager.KindOfPushedKey key, boolean state) {
-        inputManager.set(key, state);
+        ourInstance.inputManager.set(key, state);
     }
 
     public static boolean getKeyState(InputManager.KindOfPushedKey key) {
-        return inputManager.get(key);
+        return ourInstance.inputManager.get(key);
+    }
+
+    /**
+     * ゴール処理リクエストメソッド
+     */
+    public static void requestGoal() {
+        ourInstance.stop();  // 処理の停止
+        TitleController.getInstance().show();
     }
 
     /**

--- a/src/application/component/system/character/factory/PlayerFactory.java
+++ b/src/application/component/system/character/factory/PlayerFactory.java
@@ -2,15 +2,14 @@ package application.component.system.character.factory;
 
 import application.component.objects.GameObject;
 import application.component.objects.character.PlayableCharacter;
-import application.component.objects.character.implement_character.TMPCharacter;
 import application.component.system.GameManager;
-import application.component.system.character.controller.CharacterController;
 import application.component.system.character.controller.Player;
 import javafx.application.Platform;
-// import com.sun.javafx.geom.Point2D;
 
-import java.awt.Point;
+import java.awt.*;
 import java.util.Optional;
+
+// import com.sun.javafx.geom.Point2D;
 
 /**
  * プレイヤーが操作するキャラクターを生成するクラス
@@ -31,6 +30,7 @@ public class PlayerFactory extends CharacterFactory<Player> {
      * @return
      */
     public static PlayerFactory getInstance(Point createPosition) {
+        ourInstance.createdCharacterController = null;  // 前コントローラの削除
         ourInstance.setCreatePosition(createPosition);  // 位置の更新
         return ourInstance;
     }
@@ -47,7 +47,6 @@ public class PlayerFactory extends CharacterFactory<Player> {
     private static void setCreatePosition(Point createPosition) {
         ourInstance.createPosition = createPosition;
     }
-
 
     /**
      * 保持するキャラクターコントローラを取得

--- a/src/application/controller/GameController.java
+++ b/src/application/controller/GameController.java
@@ -45,12 +45,11 @@ public class GameController implements Initializable {
         // drawPaneにフォーカスを移す
         drawPane.setFocusTraversable(true);
         drawPane.requestFocus();
-
-        gameManager = GameManager.getInstance(drawPane, 1);
-        gameManager.start();
     }
 
     public static GameController getInstance() {
+        gc.gameManager = GameManager.getInstance(gc.drawPane, 1);
+        gc.gameManager.start();
         return gc;
     }
 


### PR DESCRIPTION
# 概要

ゴールオブジェクトに当たったら、タイトル画面に戻るように修正した。

# 手順

1. ゴールへ行く
2. ゴールに衝突したら、タイトル画面に戻ることを確認する
3. 再度、スタートボダンを押すことで、ゲームが始まることを確認する

# 関連Issue

#66 