### PR TITLE
プレイヤーが無効状態になったら、敵が追尾しないように修正した

### DIFF
--- a/src/application/component/system/character/controller/Enemy.java
+++ b/src/application/component/system/character/controller/Enemy.java
@@ -37,7 +37,7 @@ public class Enemy extends CharacterController {
         if ( playerCharacterController.isPresent() ) {
             Point playerPos = playerCharacterController.get().getCharacter().getPosition();
             //== プレイヤーキャラクターが索敵範囲にいる場合
-            if ( playerPos.distance(character.getPosition()) < character.getRange()) {
+            if ( playerPos.distance(character.getPosition()) < character.getRange() && !playerCharacterController.get().getCharacter().getLifeTime().isPresent() ) {
                 int distanceX = playerPos.x - character.getPosition().x;
                 int distanceY = playerPos.y - character.getPosition().y;
                 speedX = character.getDefaultSpeed() * (int)Math.signum(distanceX);


### PR DESCRIPTION
# 概要

 プレイヤーのキャラクターがHP0になり、無効状態となったら、敵が追尾しなくなり、待機状態に移るように変更した。