### PR TITLE
最大化設定の修正

### DIFF
--- a/src/application/Main.java
+++ b/src/application/Main.java
@@ -22,7 +22,7 @@ public class Main extends Application {
 
             this.primaryStage.setTitle("JavaGame");  // タイトル設定
             this.primaryStage.setResizable(false);   // ウィンドウサイズの固定
-            this.primaryStage.initStyle(StageStyle.UTILITY);  // 最大化・最小化の無効
+            this.primaryStage.setMaximized(false);   // 最大化の無効
 
             TitleController.getInstance().show();  // タイトル部分のシーンを挿入
             this.primaryStage.show();


### PR DESCRIPTION
#  概要

ウィンドウの最大化を無効にするためにスタイルを用いていたが、これを用いると、アイコンの表示などもされないことにきづいたので、別メソッドを用いて最大化の無効化を実現した。